### PR TITLE
Skin format

### DIFF
--- a/examples/analog/vcc_and_gnd.json
+++ b/examples/analog/vcc_and_gnd.json
@@ -10,7 +10,10 @@
           },
           "connections": {
             "A": [ 2 ]
-          }
+          },
+          "attributes": {
+            "value": "+12V",
+          },
         },
         "gnd": {
           "type": "gnd",

--- a/lib/analog.svg
+++ b/lib/analog.svg
@@ -47,14 +47,14 @@ text {
 <!-- power -->
 <g s:type="vcc" s:width="20" s:height="30" transform="translate(5,20)">
   <s:alias val="vcc" />
-  <text x="10" y="-4" class="nodelabel">VCC</text>
+  <text x="10" y="-4" class="nodelabel" s:attribute="name">VCC</text>
   <path d="M0,0 H20 L10,15 Z M10,15 V30"/>
   <g s:x="10" s:y="30" s:pid="A"/>
 </g>
 
 <g s:type="vee" s:width="20" s:height="30" transform="translate(40,35)">
   <s:alias val="vee" />
-  <text x="10" y="10" class="nodelabel">VEE</text>
+  <text x="10" y="10" class="nodelabel" s:attribute="name">VEE</text>
   <path d="M0,0 H20 L10,-15 Z M10,-15 V-30"/>
   <g s:x="10" s:y="-30" s:pid="A"/>
 </g>
@@ -68,14 +68,14 @@ text {
 
 <!-- signal -->
 <g s:type="inputExt" s:width="30" s:height="20" transform="translate(5,70)">
-  <text x="15" y="-4" class="nodelabel">input</text>
+  <text x="15" y="-4" class="nodelabel" s:attribute="ref">input</text>
   <s:alias val="$_inputExt_"/>
   <path d="M0,0 V20 H15 L30,10 15,0 Z"/>
   <g s:x="30" s:y="10" s:pid="Y" s:dir="lateral"/>
 </g>
 
 <g s:type="outputExt" s:width="30" s:height="20" transform="translate(60,70)">
-  <text x="15" y="-4" class="nodelabel">output</text>
+  <text x="15" y="-4" class="nodelabel" s:attribute="ref">output</text>
   <s:alias val="$_outputExt_"/>
   <path d="M30,0 V20 H15 L0,10 15,0 Z"/>
   <g s:x="0" s:y="10" s:pid="A" s:dir="lateral"/>
@@ -247,7 +247,7 @@ text {
 <!-- builtin -->
 <g s:type="split" s:width="5" s:height="40" transform="translate(5,400)">
   <rect width="5" height="40" class="splitjoinBody"
-        x="0" y="0" style="fill:#000000"/>
+        x="0" y="0" style="fill:#000000" s:generic="body"/>
   <s:alias val="$_split_"/>
   <g s:x="0" s:y="20" s:pid="in"  s:dir="lateral"/>
   <g transform="translate(5,10)"
@@ -264,7 +264,7 @@ text {
 
 <g s:type="join" s:width="4" s:height="40" transform="translate(100,400)">
   <rect width="5" height="40" class="splitjoinBody"
-        x="0" y="0" style="fill:#000000"/>
+        x="0" y="0" style="fill:#000000" s:generic="body"/>
   <s:alias val="$_join_"/>
   <g s:x="5" s:y="20" s:pid="out" s:dir="lateral"/>
   <g transform="translate(0,10)"
@@ -278,8 +278,8 @@ text {
 </g>
 
 <g s:type="generic" s:width="30" s:height="40" transform="translate(150, 400)">
-  <text x="15" y="-4" class="nodelabel">generic</text>
-  <rect width="30" height="40" x="0" y="0"/>
+  <text x="15" y="-4" class="nodelabel" s:attribute="ref">generic</text>
+  <rect width="30" height="40" x="0" y="0" s:generic="body"/>
   <g transform="translate(30,10)"
      s:x="30" s:y="10" s:pid="out0" s:dir="lateral">
     <text x="5" y="-4">out0</text>

--- a/lib/default.svg
+++ b/lib/default.svg
@@ -182,14 +182,14 @@ text {
   </g>
 
   <g s:type="inputExt" transform="translate(50,200)" s:width="30" s:height="20">
-    <text x="15" y="-4" class="nodelabel">input</text>
+    <text x="15" y="-4" class="nodelabel" s:attribute="ref">input</text>
     <s:alias val="$_inputExt_"/>
     <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" />
     <g s:x="28" s:y="10" s:pid="Y"/>
   </g>
 
   <g s:type="constant" transform="translate(150,200)" s:width="30" s:height="20">
-    <text x="15" y="-4" class="nodelabel">constant</text>
+    <text x="15" y="-4" class="nodelabel" s:attribute="ref">constant</text>
 
     <s:alias val="$_constant_"/>
     <rect width="30" height="20" />
@@ -198,7 +198,7 @@ text {
   </g>
 
   <g s:type="outputExt" transform="translate(250,200)" s:width="30" s:height="20">
-    <text x="15" y="-4" class="nodelabel">output</text>
+    <text x="15" y="-4" class="nodelabel" s:attribute="ref">output</text>
     <s:alias val="$_outputExt_"/>
     <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" />
 
@@ -206,7 +206,7 @@ text {
   </g>
 
   <g s:type="split" transform="translate(350,200)" s:width="5" s:height="40">
-    <rect width="5" height="40" class="splitjoinBody"/>
+    <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_split_"/>
 
     <g s:x="0" s:y="20" s:pid="in"/>
@@ -219,7 +219,7 @@ text {
   </g>
 
   <g s:type="join" transform="translate(450,200)" s:width="4" s:height="40">
-    <rect width="5" height="40" class="splitjoinBody"/>
+    <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20"  s:pid="out"/>
     <g transform="translate(0, 10)" s:x="0" s:y="10" s:pid="in0">
@@ -231,8 +231,8 @@ text {
   </g>
 
   <g s:type="generic" transform="translate(550,200)" s:width="30" s:height="40">
-    <text x="15" y="-4" class="nodelabel">generic</text>
-    <rect width="30" height="40" />
+    <text x="15" y="-4" class="nodelabel" s:attribute="ref">generic</text>
+    <rect width="30" height="40" s:generic="body"/>
 
     <g transform="translate(30, 10)" s:x="30" s:y="10" s:pid="out0">
       <text x="5" y="-4" style="fill:#000; stroke:none">out0</text>

--- a/lib/index.js
+++ b/lib/index.js
@@ -453,7 +453,11 @@ function getLateralPortPids(template) {
         if (element instanceof Array && tag == 'g') {
             var attrs = element[1];
             if (attrs['s:dir']) {
-                return attrs['s:dir'] == 'lateral'; 
+                return attrs['s:dir'] == 'lateral';
+            }
+            if (attrs['s:position']) {
+              return attrs['s:position'] == 'left' ||
+                     attrs['s:position'] == 'right';
             }
             return false;
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -165,6 +165,17 @@ function setTextAttribute(tempclone, attribute, value) {
     });
 }
 
+function setGenericSize(tempclone, width, height) {
+    onml.traverse(tempclone, {
+        enter: function(node, parent) {
+            if (node.name == 'rect' && node.attr['s:generic'] == 'body') {
+                //node.attr.width = width;
+                node.attr.height = height;
+            }
+        }
+    });
+}
+
 function klayed_out(g, module, skin_data) {
     var nodes = _.map(module.nodes, function(n){
         var kchild = _.find(g.children,function(c) {
@@ -183,7 +194,7 @@ function klayed_out(g, module, skin_data) {
         }
         else if (n.type == '$_split_')
         {
-            tempclone[2][1].height = Number(getGenericHeight(template, n));
+            setGenericSize(tempclone, 0, Number(getGenericHeight(template, n)));
             var outPorts = getPortsWithPrefix(template, 'out');
             var gap = Number(outPorts[1][1]['s:y']) - Number(outPorts[0][1]['s:y']);
             var startY = Number(outPorts[0][1]['s:y']);
@@ -200,7 +211,7 @@ function klayed_out(g, module, skin_data) {
         }
         else if (n.type == '$_join_')
         {
-            tempclone[2][1].height = Number(getGenericHeight(template, n));
+            setGenericSize(tempclone, 0, Number(getGenericHeight(template, n)));
             var inPorts = getPortsWithPrefix(template, 'in');
             var gap = Number(inPorts[1][1]['s:y']) - Number(inPorts[0][1]['s:y']);
             var startY = Number(inPorts[0][1]['s:y']);
@@ -217,7 +228,7 @@ function klayed_out(g, module, skin_data) {
         }
         else if (template[1]['s:type'] == 'generic')
         {
-            tempclone[3][1].height = Number(getGenericHeight(template, n));
+            setGenericSize(tempclone, 0, Number(getGenericHeight(template, n)));
             var inPorts = getPortsWithPrefix(template, 'in');
             var ingap = Number(inPorts[1][1]['s:y']) - Number(inPorts[0][1]['s:y']);
             var instartY = Number(inPorts[0][1]['s:y']);

--- a/lib/index.js
+++ b/lib/index.js
@@ -157,7 +157,7 @@ function removeDummyEdges(g) {
 
 function setTextAttribute(tempclone, attribute, value) {
     onml.traverse(tempclone, {
-        enter: function(node, parent) {
+        enter: function(node) {
             if (node.name == 'text' && node.attr['s:attribute'] == attribute) {
                 node.full[2] = value;
             }
@@ -165,11 +165,10 @@ function setTextAttribute(tempclone, attribute, value) {
     });
 }
 
-function setGenericSize(tempclone, width, height) {
+function setGenericSize(tempclone, height) {
     onml.traverse(tempclone, {
-        enter: function(node, parent) {
+        enter: function(node) {
             if (node.name == 'rect' && node.attr['s:generic'] == 'body') {
-                //node.attr.width = width;
                 node.attr.height = height;
             }
         }
@@ -194,7 +193,7 @@ function klayed_out(g, module, skin_data) {
         }
         else if (n.type == '$_split_')
         {
-            setGenericSize(tempclone, 0, Number(getGenericHeight(template, n)));
+            setGenericSize(tempclone, Number(getGenericHeight(template, n)));
             var outPorts = getPortsWithPrefix(template, 'out');
             var gap = Number(outPorts[1][1]['s:y']) - Number(outPorts[0][1]['s:y']);
             var startY = Number(outPorts[0][1]['s:y']);
@@ -211,7 +210,7 @@ function klayed_out(g, module, skin_data) {
         }
         else if (n.type == '$_join_')
         {
-            setGenericSize(tempclone, 0, Number(getGenericHeight(template, n)));
+            setGenericSize(tempclone, Number(getGenericHeight(template, n)));
             var inPorts = getPortsWithPrefix(template, 'in');
             var gap = Number(inPorts[1][1]['s:y']) - Number(inPorts[0][1]['s:y']);
             var startY = Number(inPorts[0][1]['s:y']);
@@ -228,7 +227,7 @@ function klayed_out(g, module, skin_data) {
         }
         else if (template[1]['s:type'] == 'generic')
         {
-            setGenericSize(tempclone, 0, Number(getGenericHeight(template, n)));
+            setGenericSize(tempclone, Number(getGenericHeight(template, n)));
             var inPorts = getPortsWithPrefix(template, 'in');
             var ingap = Number(inPorts[1][1]['s:y']) - Number(inPorts[0][1]['s:y']);
             var instartY = Number(inPorts[0][1]['s:y']);

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ function render(skin_data, yosys_netlist, done) {
         module_name = Object.keys(yosys_netlist.modules)[0];
     }
 
-    var module = getReformattedModule(yosys_netlist.modules[module_name]);
+    var module = getReformattedModule(yosys_netlist.modules[module_name], skin);
     // this can be skipped if there are no 0's or 1's
     if (layoutProps.constants !== false) {
         addConstants(module);
@@ -447,24 +447,50 @@ function getPortsWithPrefix(template, prefix)
     return ports;
 }
 
-function getLateralPortPids(template) {
+function filterPortPids(template, filter) {
     var ports = _.filter(template, function(element) {
         var tag = element[0];
         if (element instanceof Array && tag == 'g') {
             var attrs = element[1];
-            if (attrs['s:dir']) {
-                return attrs['s:dir'] == 'lateral';
-            }
-            if (attrs['s:position']) {
-              return attrs['s:position'] == 'left' ||
-                     attrs['s:position'] == 'right';
-            }
-            return false;
+            return filter(attrs);
         }
         return false;
     });
     return _.map(ports, function(port) {
         return port[1]['s:pid'];
+    });
+}
+
+function getLateralPortPids(template) {
+    return filterPortPids(template, (attrs) => {
+        if (attrs['s:dir']) {
+            return attrs['s:dir'] == 'lateral';
+        }
+        if (attrs['s:position']) {
+            return attrs['s:position'] == 'left' ||
+            attrs['s:position'] == 'right';
+        }
+        return false;
+    });
+}
+
+function getInputPortPids(template) {
+    return filterPortPids(template, (attrs) => {
+        if (attrs['s:position']) {
+            return attrs['s:position'] == 'left' ||
+                   attrs['s:position'] == 'top';
+        }
+        return false;
+    });
+}
+
+function getOutputPortPids(template) {
+    return filterPortPids(template, (attrs) => {
+        if (attrs['s:position']) {
+            return attrs['s:position'] == 'right' ||
+                   attrs['s:position'] == 'bottom';
+        }
+        return false;
     });
 }
 
@@ -644,7 +670,7 @@ function getCellPortList(cell, direction)
 
 // returns a reformatted module
 // a flat module has a list of nodes that include all input and output ports
-function getReformattedModule(module)
+function getReformattedModule(module, skin)
 {
     var ports= toArray(module.ports);
     var inputPorts = _.filter(ports, function(p) {
@@ -658,6 +684,16 @@ function getReformattedModule(module)
     outputPorts.forEach(function(p){p.type='$_outputExt_';});
     cells.forEach(function(c)
     {
+        var template = findSkinType(skin, c.type);
+        if (!c.port_directions) {
+            c.port_directions = {};
+        }
+        getInputPortPids(template).forEach((pid) => {
+            c.port_directions[pid] = 'input';
+        });
+        getOutputPortPids(template).forEach((pid) => {
+            c.port_directions[pid] = 'output';
+        });
         c.inputPorts = getCellPortList(c,'input');
         c.outputPorts = getCellPortList(c,'output');
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -155,6 +155,16 @@ function removeDummyEdges(g) {
     }
 }
 
+function setTextAttribute(tempclone, attribute, value) {
+    onml.traverse(tempclone, {
+        enter: function(node, parent) {
+            if (node.name == 'text' && node.attr['s:attribute'] == attribute) {
+                node.full[2] = value;
+            }
+        }
+    });
+}
+
 function klayed_out(g, module, skin_data) {
     var nodes = _.map(module.nodes, function(n){
         var kchild = _.find(g.children,function(c) {
@@ -162,16 +172,14 @@ function klayed_out(g, module, skin_data) {
         });
         var template = findSkinType(skin_data, n.type);
         var tempclone = clone(template);
+        setTextAttribute(tempclone, 'ref', n.key);
+        if (n.attributes && n.attributes.value) {
+            setTextAttribute(tempclone, 'name', n.attributes.value);
+        }
         tempclone[1].transform = 'translate(' + kchild.x+','+kchild.y+')';
-        if (n.type == '$_constant_' ||
-            n.type == '$_inputExt_' ||
-            n.type == '$_outputExt_') {
-            tempclone[2][2] = n.key;
-            if (n.type == '$_constant_' && n.key.length > 3) {
-                var num = parseInt(n.key, 2);
-                tempclone[2][2] = '0x'+num.toString(16);
-
-            }
+        if (n.type == '$_constant_' && n.key.length > 3) {
+            var num = parseInt(n.key, 2);
+            setTextAttribute(tempclone, 'ref', '0x'+num.toString(16));
         }
         else if (n.type == '$_split_')
         {


### PR DESCRIPTION
Adds the following attributes to skin format:

- `s:attribute="ref|name"` can be set on text
- `s:position="top|bottom|left|right"` can be set on pins
- `s:generic="body"` can be set on rects

Closes #34 
Relates-to #18 

Uses qeda to generate skin file and therefore makes #35, #17, #33 unnecessary.
https://github.com/qeda/qeda/pull/47

![screenshot from 2018-01-31 18-21-46](https://user-images.githubusercontent.com/741807/35674216-3123d082-0744-11e8-8ea7-a1e86a7bc107.png)

