### PR TITLE
Fix lateral checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ node_modules
 out.svg
 test/*.json
 test/*.svg
-examples/**/*.json
+examples/*.json
 examples/**/*.svg
 examples/**/*.png
 .yosys_extra

--- a/examples/analog/common_emitter_full.json
+++ b/examples/analog/common_emitter_full.json
@@ -1,0 +1,186 @@
+{
+  "modules": {
+    "Common Emitter": {
+      "cells": {
+        "C1": {
+          "connections": {
+            "A": [
+              12
+            ],
+            "B": [
+              85
+            ]
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "output"
+          },
+          "type": "c_v"
+        },
+        "C2": {
+          "connections": {
+            "A": [
+              70
+            ],
+            "B": [
+              10
+            ]
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "output"
+          },
+          "type": "c_h"
+        },
+        "Q": {
+          "connections": {
+            "B": [
+              10
+            ],
+            "C": [
+              18
+            ],
+            "E": [
+              12
+            ]
+          },
+          "port_directions": {
+            "B": "input",
+            "C": "input",
+            "E": "output"
+          },
+          "type": "q_npn"
+        },
+        "R1": {
+          "connections": {
+            "A": [
+              80
+            ],
+            "B": [
+              18
+            ]
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "output"
+          },
+          "type": "r_v"
+        },
+        "R2": {
+          "connections": {
+            "A": [
+              12
+            ],
+            "B": [
+              83
+            ]
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "output"
+          },
+          "type": "r_v"
+        },
+        "R3": {
+          "connections": {
+            "A": [
+              86
+            ],
+            "B": [
+              10
+            ]
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "output"
+          },
+          "type": "r_v"
+        },
+        "R4": {
+          "connections": {
+            "A": [
+              10
+            ],
+            "B": [
+              89
+            ]
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "output"
+          },
+          "type": "r_v"
+        },
+        "gnd83": {
+          "connections": {
+            "A": [
+              83
+            ]
+          },
+          "port_directions": {
+            "A": "input"
+          },
+          "type": "gnd"
+        },
+        "gnd85": {
+          "connections": {
+            "A": [
+              85
+            ]
+          },
+          "port_directions": {
+            "A": "input"
+          },
+          "type": "gnd"
+        },
+        "gnd89": {
+          "connections": {
+            "A": [
+              89
+            ]
+          },
+          "port_directions": {
+            "A": "input"
+          },
+          "type": "gnd"
+        },
+        "vcc80": {
+          "connections": {
+            "A": [
+              80
+            ]
+          },
+          "port_directions": {
+            "A": "output"
+          },
+          "type": "vcc"
+        },
+        "vcc86": {
+          "connections": {
+            "A": [
+              86
+            ]
+          },
+          "port_directions": {
+            "A": "output"
+          },
+          "type": "vcc"
+        }
+      },
+      "ports": {
+        "vin": {
+          "bits": [
+            70
+          ],
+          "direction": "input"
+        },
+        "vout": {
+          "bits": [
+            18
+          ],
+          "direction": "output"
+        }
+      }
+    }
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -999,7 +999,7 @@ function createWires(module, skin)
         // find all ports connected to the same net
         n.inputPorts.forEach(function(port) {
             port.parentNode = n;
-            if (lateralPids.includes(port.key) || (template[1]['s:type'] === 'generic' && layoutProps.genericsLaterals)) {
+            if (lateralPids.indexOf(port.key) !== -1 || (template[1]['s:type'] === 'generic' && layoutProps.genericsLaterals)) {
                 addToDefaultDict(lateralsByNet, arrayToBitstring(port.value), port);
             } else {
                 addToDefaultDict(ridersByNet, arrayToBitstring(port.value), port);
@@ -1007,7 +1007,7 @@ function createWires(module, skin)
         });
         n.outputPorts.forEach(function(port) {
             port.parentNode = n;
-            if (lateralPids.includes(port.key) || (template[1]['s:type'] === 'generic' && layoutProps.genericsLaterals)) {
+            if (lateralPids.indexOf(port.key) !== -1 || (template[1]['s:type'] === 'generic' && layoutProps.genericsLaterals)) {
                 addToDefaultDict(lateralsByNet, arrayToBitstring(port.value), port);
             } else {
                 addToDefaultDict(driversByNet, arrayToBitstring(port.value), port);

--- a/lib/index.js
+++ b/lib/index.js
@@ -119,7 +119,7 @@ function removeDummyEdges(g) {
             }
         });
         var junct = junctEdge.junctionPoints[0];
-        
+
         var dirs = _.map(edgeGroup,function(e) {
             var s = e.sections[0];
             if (e.source == dummyId) {
@@ -999,7 +999,7 @@ function createWires(module, skin)
         // find all ports connected to the same net
         n.inputPorts.forEach(function(port) {
             port.parentNode = n;
-            if (port.key == lateralPids || (template[1]['s:type'] ==  'generic' && layoutProps.genericsLaterals == 'true')) {
+            if (lateralPids.includes(port.key) || (template[1]['s:type'] === 'generic' && layoutProps.genericsLaterals)) {
                 addToDefaultDict(lateralsByNet, arrayToBitstring(port.value), port);
             } else {
                 addToDefaultDict(ridersByNet, arrayToBitstring(port.value), port);
@@ -1007,7 +1007,7 @@ function createWires(module, skin)
         });
         n.outputPorts.forEach(function(port) {
             port.parentNode = n;
-            if (port.key == lateralPids || (template[1]['s:type'] ==  'generic'&& layoutProps.genericsLaterals == 'true')) {
+            if (lateralPids.includes(port.key) || (template[1]['s:type'] === 'generic' && layoutProps.genericsLaterals)) {
                 addToDefaultDict(lateralsByNet, arrayToBitstring(port.value), port);
             } else {
                 addToDefaultDict(driversByNet, arrayToBitstring(port.value), port);


### PR DESCRIPTION
I noticed this code

```
port.key == lateralPids 
```

Which when `'A' == [ 'A' ]` gives `true` but when `'A' == [ 'A', 'B' ]` is `false` so I switched it to using `[].includes`. 

It seems fine with existing analog and digital (though I don't know them so well) examples but the more complicated common_emitter example goes a bit weird:

before:
![](https://cloud.monostable.co.uk/original.svg)

after:
![](https://cloud.monostable.co.uk/fixed.svg)