### PR TITLE
Adding _DFF_N_ to Yosys symbols and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ Here's an analog example.
 ## Skin File
 It pulls the node icons and configuration options from a SVG skin file. This our default digital skin file.
 
-<img src="https://raw.githubusercontent.com/nturley/netlistsvg/master/lib/default.svg?sanitize=true" width="700" height="250">
+<img src="https://raw.githubusercontent.com/nturley/netlistsvg/master/lib/default.svg?sanitize=true" width="800" height="300">
 
 This is our analog skin file.
 

--- a/lib/default.svg
+++ b/lib/default.svg
@@ -1,6 +1,7 @@
 <svg  xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink"
-  xmlns:s="https://github.com/nturley/netlistsvg">
+  xmlns:s="https://github.com/nturley/netlistsvg"
+  width="800" height="300">
   <s:properties>
     <s:layoutEngine
       org.eclipse.elk.layered.spacing.nodeNodeBetweenLayers="35"
@@ -172,57 +173,7 @@ text {
     <g s:x="25" s:y="12.5" s:pid="Y"/>
   </g>
 
-  <g s:type="lt" transform="translate(350,150)" s:width="25" s:height="25">
-    <s:alias val="$lt"/>
-
-    <circle r="12.5" cx="12.5" cy="12.5" class="$cell_id"/>
-    <line x1="7.5" x2="17.5" y1="12.5" y2="7.5" class="$cell_id"/>
-    <line x1="7.5" x2="17.5" y1="12.5" y2="17.5" class="$cell_id"/>
-
-    <g s:x="3" s:y="5" s:pid="A"/>
-    <g s:x="3" s:y="20" s:pid="B"/>
-    <g s:x="25" s:y="12.5" s:pid="Y"/>
-  </g>
-
-  <g s:type="le" transform="translate(450,150)" s:width="25" s:height="25">
-    <s:alias val="$le"/>
-
-    <circle r="12.5" cx="12.5" cy="12.5" class="$cell_id"/>
-    <line x1="7.5" x2="17.5" y1="12.5" y2="7.5" class="$cell_id"/>
-    <line x1="7.5" x2="17.5" y1="12.5" y2="17.5" class="$cell_id"/>
-    <line x1="7.5" x2="17.5" y1="15" y2="20" class="$cell_id"/>
-
-    <g s:x="3" s:y="5" s:pid="A"/>
-    <g s:x="3" s:y="20" s:pid="B"/>
-    <g s:x="25" s:y="12.5" s:pid="Y"/>
-  </g>
-
-  <g s:type="ge" transform="translate(550,150)" s:width="25" s:height="25">
-    <s:alias val="$ge"/>
-
-    <circle r="12.5" cx="12.5" cy="12.5" class="$cell_id"/>
-    <line x1="7.5" x2="17.5" y1="7.5" y2="12.5" class="$cell_id"/>
-    <line x1="7.5" x2="17.5" y1="17.5" y2="12.5" class="$cell_id"/>
-    <line x1="7.5" x2="17.5" y1="20" y2="15" class="$cell_id"/>
-
-    <g s:x="3" s:y="5" s:pid="A"/>
-    <g s:x="3" s:y="20" s:pid="B"/>
-    <g s:x="25" s:y="12.5" s:pid="Y"/>
-  </g>
-
-  <g s:type="gt" transform="translate(650,150)" s:width="25" s:height="25">
-    <s:alias val="$gt"/>
-
-    <circle r="12.5" cx="12.5" cy="12.5" class="$cell_id"/>
-    <line x1="7.5" x2="17.5" y1="7.5" y2="12.5" class="$cell_id"/>
-    <line x1="7.5" x2="17.5" y1="17.5" y2="12.5" class="$cell_id"/>
-
-    <g s:x="3" s:y="5" s:pid="A"/>
-    <g s:x="3" s:y="20" s:pid="B"/>
-    <g s:x="25" s:y="12.5" s:pid="Y"/>
-  </g>
-
-  <g s:type="dff" transform="translate(750,150)" s:width="30" s:height="40">
+  <g s:type="dff" transform="translate(350,150)" s:width="30" s:height="40">
     <s:alias val="$dff"/>
     <s:alias val="$_DFF_"/>
     <s:alias val="$_DFF_P_"/>
@@ -236,14 +187,77 @@ text {
     <g s:x="0" s:y="10" s:pid="D"/>
   </g>
 
-  <g s:type="inputExt" transform="translate(50,200)" s:width="30" s:height="20">
+  <g s:type="dffn" transform="translate(450,150)" s:width="30" s:height="40">
+    <s:alias val="$_DFF_N_"/>
+
+    <rect width="30" height="40" x="0" y="0" class="$cell_id"/>
+    <path d="M0,35 L5,30 L0,25" class="$cell_id"/>
+    <circle cx="-3" cy="30" r="3" class="$cell_id"/>
+
+    <g s:x="30" s:y="10" s:pid="Q"/>
+    <g s:x="-6" s:y="30" s:pid="CLK"/>
+    <g s:x="-6" s:y="30" s:pid="C"/>
+    <g s:x="0" s:y="10" s:pid="D"/>
+  </g>
+
+  <g s:type="lt" transform="translate(50,200)" s:width="25" s:height="25">
+    <s:alias val="$lt"/>
+
+    <circle r="12.5" cx="12.5" cy="12.5" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="12.5" y2="7.5" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="12.5" y2="17.5" class="$cell_id"/>
+
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="25" s:y="12.5" s:pid="Y"/>
+  </g>
+
+  <g s:type="le" transform="translate(150,200)" s:width="25" s:height="25">
+    <s:alias val="$le"/>
+
+    <circle r="12.5" cx="12.5" cy="12.5" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="12.5" y2="7.5" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="12.5" y2="17.5" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="15" y2="20" class="$cell_id"/>
+
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="25" s:y="12.5" s:pid="Y"/>
+  </g>
+
+  <g s:type="ge" transform="translate(250,200)" s:width="25" s:height="25">
+    <s:alias val="$ge"/>
+
+    <circle r="12.5" cx="12.5" cy="12.5" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="7.5" y2="12.5" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="17.5" y2="12.5" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="20" y2="15" class="$cell_id"/>
+
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="25" s:y="12.5" s:pid="Y"/>
+  </g>
+
+  <g s:type="gt" transform="translate(350,200)" s:width="25" s:height="25">
+    <s:alias val="$gt"/>
+
+    <circle r="12.5" cx="12.5" cy="12.5" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="7.5" y2="12.5" class="$cell_id"/>
+    <line x1="7.5" x2="17.5" y1="17.5" y2="12.5" class="$cell_id"/>
+
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="25" s:y="12.5" s:pid="Y"/>
+  </g>
+
+  <g s:type="inputExt" transform="translate(50,250)" s:width="30" s:height="20">
     <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">input</text>
     <s:alias val="$_inputExt_"/>
     <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="$cell_id"/>
     <g s:x="28" s:y="10" s:pid="Y"/>
   </g>
 
-  <g s:type="constant" transform="translate(150,200)" s:width="30" s:height="20">
+  <g s:type="constant" transform="translate(150,250)" s:width="30" s:height="20">
     <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">constant</text>
 
     <s:alias val="$_constant_"/>
@@ -252,7 +266,7 @@ text {
     <g s:x="30" s:y="10" s:pid="Y"/>
   </g>
 
-  <g s:type="outputExt" transform="translate(250,200)" s:width="30" s:height="20">
+  <g s:type="outputExt" transform="translate(250,250)" s:width="30" s:height="20">
     <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">output</text>
     <s:alias val="$_outputExt_"/>
     <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="$cell_id"/>
@@ -260,7 +274,7 @@ text {
     <g s:x="0" s:y="10" s:pid="A"/>
   </g>
 
-  <g s:type="split" transform="translate(350,200)" s:width="5" s:height="40">
+  <g s:type="split" transform="translate(350,250)" s:width="5" s:height="40">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_split_"/>
 
@@ -273,7 +287,7 @@ text {
     </g>
   </g>
 
-  <g s:type="join" transform="translate(450,200)" s:width="4" s:height="40">
+  <g s:type="join" transform="translate(450,250)" s:width="4" s:height="40">
     <rect width="5" height="40" class="splitjoinBody" s:generic="body"/>
     <s:alias val="$_join_"/>
     <g s:x="5" s:y="20"  s:pid="out"/>
@@ -285,7 +299,7 @@ text {
     </g>
   </g>
 
-  <g s:type="generic" transform="translate(550,200)" s:width="30" s:height="40">
+  <g s:type="generic" transform="translate(550,250)" s:width="30" s:height="40">
     <text x="15" y="-4" class="nodelabel $cell_id" s:attribute="ref">generic</text>
     <rect width="30" height="40" s:generic="body" class="$cell_id"/>
 


### PR DESCRIPTION
This completes some of the things I missed in #80 

- Adds a DFFN negative edge clocked flip-flop symbol
- Fixes image size in README to show all icons
- Adds size descriptor to default.svg to improve default rendering, this also fixes the visual diff in GitHub
