### PR TITLE
Fixup: Handle empty section.bendPoints

### DIFF
--- a/lib/drawModule.ts
+++ b/lib/drawModule.ts
@@ -155,12 +155,12 @@ export function removeDummyEdges(g: ElkModel.Graph) {
             const section = edge.sections[0];
             if (dummyIsSource) {
                 // get first bend or endPoint
-                if (section.bendPoints) {
+                if (section.bendPoints && section.bendPoints.length > 0) {
                     return [section.bendPoints[0]];
                 }
                 return section.endPoint;
             } else {
-                if (section.bendPoints) {
+                if (section.bendPoints && section.bendPoints.length > 0) {
                     return [_.last(section.bendPoints)];
                 }
                 return section.startPoint;


### PR DESCRIPTION
In pull request #84, the change was only made to the build/ folder,
not the lib folder where the typescript source actually is.

This causes the change to be reverted whenever "npx tsc" is run.

Fixes Issue #83 for sure.