### PR TITLE
Fix input and output ports with dots in name.

### DIFF
--- a/lib/Cell.ts
+++ b/lib/Cell.ts
@@ -252,7 +252,8 @@ export default class Cell {
         const template = this.getTemplate();
         const tempclone = clone(template);
         for (const label of cell.labels) {
-            const attrName = label.id.split('.')[2];
+            const labelIDSplit = label.id.split('.');
+            const attrName = labelIDSplit[labelIDSplit.length - 1];
             setTextAttribute(tempclone, attrName, label.text);
         }
         for (let i = 2; i < tempclone.length; i++) {


### PR DESCRIPTION
(Fixes issue #97)

This split caused inputs and outputs with (one) dot in the name to
be labeled as just "input" or "output" instead of their name.
