### PR TITLE
Update CI to node 14

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  nodejs_version: "6"
+  nodejs_version: "14"
 
 install:
   - ps: Install-Product node $env:nodejs_version


### PR DESCRIPTION
Node 14 is what comes default with Ubuntu 20.04.